### PR TITLE
[WIP] Add an IR cache to Ratter

### DIFF
--- a/.github/workflows/staticanalysis.yml
+++ b/.github/workflows/staticanalysis.yml
@@ -4,7 +4,7 @@ name: CD/CI -- staticanalysis
 on:
   push:
     branches:
-      - "**"
+      - "main"
 
   pull_request:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade jsonpickle
+
+      - name: Install pytest and test dependencies
+        run: |
           python -m pip install --upgrade pytest
           python -m pip install --upgrade mock
           python -m pip install --upgrade flask

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ name: CD/CI -- tests
 on:
   push:
     branches:
-      - "**"
+      - "main"
 
   pull_request:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.ratter
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,46 @@ as nested functions -- "un-nest" them.
 See `python ratter -h`.
 
 
+## Security
+
+### Caching and Serialisation
+
+Both the `pickle` and `jsonpickle` libraries, used for serialisation in Python,
+have known security issues which are inherited by Ratter (`jsonpickle` is used
+s.t. the cache files remain human readable). As such you should not allow cache
+files to be loaded from untrusted sources.
+
+If you are concerned about security, or you are unable to ensure cache files
+are trusted, you can run Ratter with the `--no-cache` argument to avoid the use
+of the `jsonpickle` library.
+
+
+[1] https://docs.python.org/3/library/pickle.html
+
+[2] https://jsonpickle.github.io/#jsonpickle-usage
+
+
+### Imports and `importlib`
+
+Ratter uses `importlib.util.find_spec` to locate the source code for imported
+modules when following imports. However, the function `find_spec(m)` has the
+side-effect that, when called, the parent module of `m` will be imported, thus
+the parent of `m` will be imported by Ratter and any code in the global scope
+of `m`'s parent will be executed. As such you should not run Ratter on any
+code you do not trust and would not be willing to execute.
+
+If you wish to avoid the use of `find_spec` you can set the CLI argument
+`--follow-imports 0` or `--follow-imports 1`, however, you must do so at your
+own risk as this has not been thoroughly tested.
+
+We intend to fix this vulnerability after moving to Python 3.8+ in the future,
+by using the new `importlib.metadata` library [3], which appears to not
+suffer from the same issue.
+
+
+[3] https://docs.python.org/3.8/library/importlib.metadata.html
+
+
 ## Errors and Warnings
 
 Ratter can give five types of error/warnings: raised Python errors, output

--- a/ratter/__main__.py
+++ b/ratter/__main__.py
@@ -24,6 +24,10 @@ def main(arguments: Namespace) -> None:
     """Ratter entry point."""
     load_config(arguments)
 
+    if config.dry_run:
+        print(json.dumps(config.__dict__, cls=ResultsEncoder, indent=4))
+        exit(0)
+
     file_ir, imports_ir, stats = parse_and_analyse_file()
 
     results = generate_results_from_ir(file_ir, imports_ir)
@@ -206,6 +210,8 @@ def write_results_cache(
 
 def load_config(arguments: Namespace) -> None:
     """Populate the config with the given arguments."""
+    config.dry_run = arguments.dry_run
+
     config.follow_imports = arguments.follow_imports
     config.follow_pip_imports = arguments.follow_imports >= 2
     config.follow_stdlib_imports = arguments.follow_imports >= 3
@@ -233,6 +239,8 @@ def load_config(arguments: Namespace) -> None:
     config.file = arguments.file
 
     config.cache_results = arguments.cache_results
+
+    config.ir_cache = not arguments.no_ir_cache
 
 
 if __name__ == "__main__":

--- a/ratter/__main__.py
+++ b/ratter/__main__.py
@@ -10,11 +10,11 @@ from ratter.analyser.file import RatterStats, parse_and_analyse_file
 from ratter.analyser.results import ResultsEncoder, generate_results_from_ir
 from ratter.analyser.types import FileIR, FileResults, ImportsIR
 from ratter.analyser.util import (
-    results_cache_is_valid,
     create_results_cache,
     is_blacklisted_module,
     re_filter_ir,
     re_filter_results,
+    results_cache_is_valid,
 )
 from ratter.cli import Namespace, parse_arguments
 from ratter.error import get_badness
@@ -175,7 +175,9 @@ def show_stats(stats: RatterStats) -> None:
     print(end="\n\n")
 
 
-def write_results_cache(results: FileResults, file_ir: FileIR, imports_ir: ImportsIR) -> None:
+def write_results_cache(
+    results: FileResults, file_ir: FileIR, imports_ir: ImportsIR
+) -> None:
     """Save the file results to the cache."""
     if results_cache_is_valid(config.file, config.cache_results):
         return error.ratter(f"cache for '{config.file}' is already up to date")

--- a/ratter/__main__.py
+++ b/ratter/__main__.py
@@ -10,8 +10,8 @@ from ratter.analyser.file import RatterStats, parse_and_analyse_file
 from ratter.analyser.results import ResultsEncoder, generate_results_from_ir
 from ratter.analyser.types import FileIR, FileResults, ImportsIR
 from ratter.analyser.util import (
-    cache_is_valid,
-    create_cache,
+    results_cache_is_valid,
+    create_results_cache,
     is_blacklisted_module,
     re_filter_ir,
     re_filter_results,
@@ -40,8 +40,8 @@ def main(arguments: Namespace) -> None:
     if config.show_stats:
         show_stats(stats)
 
-    if config.cache:
-        write_cache(results, file_ir, imports_ir)
+    if config.cache_results:
+        write_results_cache(results, file_ir, imports_ir)
 
 
 def show_ir(file: str, file_ir: FileIR, imports_ir: ImportsIR) -> None:
@@ -175,9 +175,9 @@ def show_stats(stats: RatterStats) -> None:
     print(end="\n\n")
 
 
-def write_cache(results: FileResults, file_ir: FileIR, imports_ir: ImportsIR) -> None:
-    """Save the file results to the file cache."""
-    if cache_is_valid(config.file, config.cache):
+def write_results_cache(results: FileResults, file_ir: FileIR, imports_ir: ImportsIR) -> None:
+    """Save the file results to the cache."""
+    if results_cache_is_valid(config.file, config.cache_results):
         return error.ratter(f"cache for '{config.file}' is already up to date")
 
     imports: Set[str] = set()
@@ -199,7 +199,7 @@ def write_cache(results: FileResults, file_ir: FileIR, imports_ir: ImportsIR) ->
 
             imports.add(sym.module_spec.origin)
 
-    create_cache(results, imports, ResultsEncoder)
+    create_results_cache(results, imports, ResultsEncoder)
 
 
 def load_config(arguments: Namespace) -> None:
@@ -230,7 +230,7 @@ def load_config(arguments: Namespace) -> None:
     config.filter_string = arguments.filter_string
     config.file = arguments.file
 
-    config.cache = arguments.cache
+    config.cache_results = arguments.cache_results
 
 
 if __name__ == "__main__":

--- a/ratter/analyser/base.py
+++ b/ratter/analyser/base.py
@@ -7,7 +7,7 @@ from itertools import product
 from typing import Dict, List, Optional
 
 from ratter import error
-from ratter.analyser.context import Context
+from ratter.analyser.context.context import Context
 from ratter.analyser.context.symbol import Import
 from ratter.analyser.types import FuncOrAsyncFunc, FunctionIR
 

--- a/ratter/analyser/cls.py
+++ b/ratter/analyser/cls.py
@@ -9,7 +9,7 @@ import ast
 from typing import List
 
 from ratter.analyser.base import NodeVisitor
-from ratter.analyser.context import Context
+from ratter.analyser.context.context import Context
 from ratter.analyser.context.symbol import Class, Func, Name, Symbol
 from ratter.analyser.function import FunctionAnalyser
 from ratter.analyser.types import (

--- a/ratter/analyser/context/__init__.py
+++ b/ratter/analyser/context/__init__.py
@@ -1,15 +1,15 @@
-from ratter.analyser.context.context import Context  # noqa: F401
-from ratter.analyser.context.context import (  # noqa: F401
-    RootContext,
-    new_context,
-)
-from ratter.analyser.context.symbol import (  # noqa: F401
-    Builtin,
-    Call,
-    Class,
-    Func,
-    Import,
-    Name,
-    Symbol,
-)
-from ratter.analyser.context.symbol_table import SymbolTable  # noqa: F401
+# from ratter.analyser.context.context import (  # noqa: F401
+#     Context,
+#     RootContext,
+#     new_context,
+# )
+# from ratter.analyser.context.symbol import (  # noqa: F401
+#     Builtin,
+#     Call,
+#     Class,
+#     Func,
+#     Import,
+#     Name,
+#     Symbol,
+# )
+# from ratter.analyser.context.symbol_table import SymbolTable  # noqa: F401

--- a/ratter/analyser/context/context.py
+++ b/ratter/analyser/context/context.py
@@ -22,7 +22,7 @@ from typing import (
     Union,
 )
 
-from ratter import config, error
+from ratter import error
 from ratter.analyser.context.symbol import (
     Builtin,
     CallTarget,
@@ -82,6 +82,8 @@ class Context:
     """
 
     def __init__(self, parent: Optional[_Context]) -> None:
+        from ratter import config
+
         self.parent = parent
         self.symbol_table = SymbolTable()
         self.file = config.current_file
@@ -249,6 +251,8 @@ class Context:
 
     def expand_starred_imports(self) -> Type[_Context]:
         """Expand starred imports to normal imports."""
+        from ratter import config
+
         seen: Set[str] = set()
 
         # Create initial starred list for BFS
@@ -400,6 +404,8 @@ class RootContext(Context):
 
     def register_starred_import(self, node: ast.ImportFrom) -> None:
         """Helper method for starred imports."""
+        from ratter import config
+
         if self.file is None or not self.file.endswith("__init__.py"):
             error.warning(
                 f"do not use 'from {node.module} import *', be explicit", node
@@ -419,6 +425,8 @@ class RootContext(Context):
 
     def register_relative_import(self, node: ast.ImportFrom) -> None:
         """Helper method for relative imports."""
+        from ratter import config
+
         base = module_name_from_file_path(config.current_file)
 
         if base is None:

--- a/ratter/analyser/context/symbol.py
+++ b/ratter/analyser/context/symbol.py
@@ -13,8 +13,6 @@ from importlib.util import find_spec
 from itertools import accumulate, chain, filterfalse
 from typing import Dict, List, Optional, Tuple, Union
 
-from ratter import config
-
 
 @dataclass
 class Symbol:
@@ -74,6 +72,9 @@ class Func(Symbol):
     defined_in: Optional[str] = None
 
     def __post_init__(self) -> None:
+        # NOTE pytest fails from circular import if in global scope
+        from ratter import config
+
         self.defined_in = config.current_file
 
     def __hash__(self) -> int:
@@ -97,6 +98,9 @@ class Class(Symbol):
     defined_in: Optional[str] = None
 
     def __post_init__(self) -> None:
+        # NOTE pytest fails from circular import if in global scope
+        from ratter import config
+
         self.defined_in = config.current_file
 
     def __hash__(self) -> int:

--- a/ratter/analyser/function.py
+++ b/ratter/analyser/function.py
@@ -6,15 +6,8 @@ from typing import List, Optional, Tuple
 
 from ratter import error
 from ratter.analyser.base import NodeVisitor
-from ratter.analyser.context import (
-    Call,
-    Class,
-    Context,
-    Func,
-    Name,
-    Symbol,
-    new_context,
-)
+from ratter.analyser.context.context import Context, new_context
+from ratter.analyser.context.symbol import Call, Class, Func, Name, Symbol
 from ratter.analyser.types import (
     AnyAssign,
     AnyFunctionDef,

--- a/ratter/analyser/ir_dag.py
+++ b/ratter/analyser/ir_dag.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from ratter import config, error
-from ratter.analyser.context import (
+from ratter.analyser.context.symbol import (
     Builtin,
     Call,
     Class,

--- a/ratter/analyser/results.py
+++ b/ratter/analyser/results.py
@@ -1,7 +1,7 @@
 """Ratter functions for producing and displaying results."""
 import json
 
-from ratter.analyser.context import Symbol
+from ratter.analyser.context.symbol import Symbol
 from ratter.analyser.ir_dag import IrDagNode
 from ratter.analyser.types import FileIR, FileResults, ImportsIR
 
@@ -15,6 +15,9 @@ class ResultsEncoder(json.JSONEncoder):
 
         if isinstance(obj, Symbol):
             return repr(obj)
+
+        if obj.__class__.__name__ == "RatterCache":
+            return str(obj)
 
         return super().default(obj)
 

--- a/ratter/analyser/types.py
+++ b/ratter/analyser/types.py
@@ -113,9 +113,9 @@ class FileIR:
     """Provide a `Mapping[Func, FunctionIR]`, with context."""
 
     def __init__(self, context):
-        # `self.context: Context` omitted to avoid circular import, hopefully
-        # mypy's inference is sufficient
-        self.context = context
+        from ratter.analyser.context.context import Context
+
+        self.context: Context = context
         self._file_ir: _FileIR = dict()
 
     def __eq__(self, other) -> bool:

--- a/ratter/analyser/util.py
+++ b/ratter/analyser/util.py
@@ -1062,13 +1062,13 @@ def get_file_hash(filepath: str, blocksize: int = 2**20) -> str:
     return _hash.hexdigest()
 
 
-def cache_is_valid(filepath: str, cache_filepath: str) -> bool:
+def results_cache_is_valid(filepath: str, results_cache_filepath: str) -> bool:
     """Return `True` if the cache has the correct hash."""
     if not isfile(filepath):
         return False
 
-    if isfile(cache_filepath):
-        with open(cache_filepath, "r") as f:
+    if isfile(results_cache_filepath):
+        with open(results_cache_filepath, "r") as f:
             cache: Dict[str, Any] = json.load(f)
     else:
         return False
@@ -1091,10 +1091,10 @@ def cache_is_valid(filepath: str, cache_filepath: str) -> bool:
     return True
 
 
-def create_cache(
+def create_results_cache(
     results: FileResults, imports: Set[str], encoder: json.JSONEncoder
 ) -> None:
-    """Create a the cache and write it to the cache file.
+    """Create a the results cache and write it to the file.
 
     NOTE:
         The attribute `imports` should hold the file name of every directly and
@@ -1131,5 +1131,5 @@ def create_cache(
     ]
     to_cache["results"] = deepcopy(results)
 
-    with open(config.cache, "w") as f:
+    with open(config.cache_results, "w") as f:
         json.dump(to_cache, f, cls=encoder, indent=4)

--- a/ratter/analyser/util.py
+++ b/ratter/analyser/util.py
@@ -49,6 +49,7 @@ from ratter.analyser.types import (
     Nameable,
     StrictlyNameable,
 )
+from ratter.version import __version__
 
 # The prefix given to local constants, literals, etc to produce a name
 # E.g. "hi" -> get_basename_fullname_pair(.) = "@Str"
@@ -1076,6 +1077,9 @@ def results_cache_is_valid(filepath: str, results_cache_filepath: str) -> bool:
     received_hash = cache.get("filehash", None)
     expected_hash = get_file_hash(filepath)
 
+    if __version__ != cache.get("ratter_version", "pre-1.1.0"):
+        return False
+
     if filepath != cache.get("filepath", None):
         return False
 
@@ -1102,8 +1106,10 @@ def create_results_cache(
 
     Cache file format (JSON):
     {
-        "filepath": ...,    # the file the results belong to
-        "filehash": ...,    # the MD5 hash of the file when it was cached
+        "ratter_version": ...,  # the Ratter version the cache was created by
+
+        "filepath": ...,        # the file the results belong to
+        "filehash": ...,        # the MD5 hash of the file when it was cached
 
         "imports": [
             {"filename": ..., "filehash": ...,},
@@ -1124,6 +1130,7 @@ def create_results_cache(
     """
     to_cache = dict()
 
+    to_cache["ratter_version"] = __version__
     to_cache["filepath"] = config.file
     to_cache["filehash"] = get_file_hash(config.file)
     to_cache["imports"] = [

--- a/ratter/analyser/util.py
+++ b/ratter/analyser/util.py
@@ -550,15 +550,15 @@ def is_pip_module(module: str) -> bool:
     if spec is None or spec.origin is None:
         return False
 
-    # No backslashes, bad windows!
-    spec.origin = spec.origin.replace("\\", "/")
-
     return is_pip_filepath(spec.origin)
 
 
 def is_pip_filepath(filepath: str) -> bool:
     """Return `True` if the given filepath belongs to a pip module."""
     pip_install_locations = (".+/site-packages.*",)
+
+    # No backslashes, bad windows!
+    filepath = filepath.replace("\\", "/")
 
     return any(re.fullmatch(p, filepath) for p in pip_install_locations)
 
@@ -593,9 +593,6 @@ def is_stdlib_module(module: str) -> bool:
     if "site-packages" in spec.origin:
         return False
 
-    # No backslashes, bad windows!
-    spec.origin = spec.origin.replace("\\", "/")
-
     return is_stdlib_filepath(spec.origin)
 
 
@@ -622,6 +619,9 @@ def is_stdlib_filepath(filepath: str) -> str:
         "C:/.+/(PyPy|Python)/.+/(L|l)ib.*",
         "C:/.+/(PyPy|Python)/.+/DLLs.*",
     )
+
+    # No backslashes, bad windows!
+    filepath = filepath.replace("\\", "/")
 
     return any(re.fullmatch(p, filepath) for p in stdlib_patterns)
 

--- a/ratter/cache/__init__.py
+++ b/ratter/cache/__init__.py
@@ -1,0 +1,1 @@
+from ratter.cache.cache import FileCache, RatterCache  # noqa: F401

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Optional, Set, Type, TypeVar
 import jsonpickle
 
 from ratter.analyser.types import FileIR, FileResults
-from ratter.cache.util import get_cache_filepath, get_file_hash, get_import_filepaths
+from ratter.cache.util import (
+    get_cache_filepath,
+    get_file_hash,
+    get_import_filepaths,
+)
 from ratter.version import __version__
 
 _FileCache = TypeVar("_FileCache", bound="FileCache")

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -122,9 +122,6 @@ class FileCache:
             return False
 
         # Validate file
-        if self.filepath != self.filepath:
-            return False
-
         if self.filehash != get_file_hash(self.filepath):
             return False
 
@@ -217,9 +214,16 @@ class RatterCache:
             except FileNotFoundError:
                 return None
 
-            if cache.is_valid:
-                self.cache_by_file[filepath] = cache
-                return cache
+            if not cache.is_valid:
+                return None
+
+            if cache.filepath != filepath:
+                raise ValueError(
+                    f"cache filepath does not match real filepath, "
+                    f"'{cache.filepath}' != '{filepath}'"
+                )
+
+            return cache
 
         return None
 

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -177,7 +177,7 @@ class FileCache:
         self.set_imports()
 
         with open(cache_filepath, "w") as f:
-            f.write(jsonpickle.encode(self))
+            f.write(jsonpickle.encode(self, indent=4))
 
 
 @dataclass

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -152,6 +152,11 @@ class FileCache:
         shown if the existing cache is loaded.
 
         """
+        from ratter import config
+
+        if not config.use_cache:
+            raise RuntimeError("unable to read cache when config.use_cache is false")
+
         if not isfile(cache_filepath):
             raise FileNotFoundError(cache_filepath)
 
@@ -176,6 +181,11 @@ class FileCache:
         imports for this file may be incorrect, see `self.set_imports`.
 
         """
+        from ratter import config
+
+        if not config.save_cache:
+            raise RuntimeError("unable to read cache when config.save_cache is false")
+
         if cache_filepath is None:
             cache_filepath = get_cache_filepath(self.filepath)
 

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -1,0 +1,257 @@
+"""Hold ratter chache classes."""
+
+from dataclasses import dataclass, field
+from os.path import isfile
+from typing import Dict, List, Optional, Set, Type, TypeVar
+
+import jsonpickle
+
+from ratter.analyser.types import FileIR, FileResults
+from ratter.cache.util import get_cache_filepath, get_file_hash, get_import_filepaths
+from ratter.version import __version__
+
+_FileCache = TypeVar("_FileCache", bound="FileCache")
+
+
+import_info_by_filepath: Dict[str, Dict[str, str]] = dict()
+
+
+@dataclass
+class FileCache:
+    """Store the cache for a specific file.
+
+    The cache is designed to be JSON serialisable/un-serialisable.
+
+    Cache format (JSON):
+    ```json
+    {
+        "ratter_version": ...,  # the Ratter version the cache was created by
+
+        "filepath": ...,        # the file the results belong to
+        "filehash": ...,        # the MD5 hash of the file when it was cached
+
+        "imports": [
+            {"filename": ..., "filehash": ...,},
+        ],
+
+        "errors": [
+            ...                 # the errors produced while analysing the file
+        ],
+
+        "ir": {
+            ...                 # the IR for the analysed file
+        },
+
+        "results":
+            ...                 # the results for the analysed file
+        },
+    }
+    ```
+
+    """
+
+    ratter_version: str = __version__
+
+    filepath: str = "undefined"
+    filehash: str = "undefined"
+
+    imports: List[Dict[str, str]] = field(default_factory=list)
+
+    errors: List[str] = field(default_factory=list)
+
+    ir: Optional[FileIR] = None
+
+    results: Optional[FileResults] = None
+
+    def set_file_info(self, filepath: str) -> None:
+        """Set the file info for this cache to that of the given file."""
+        self.filepath = filepath
+        self.filehash = get_file_hash(filepath)
+
+    def set_imports(self) -> None:
+        """Set the file imports for this cache.
+
+        NOTE
+            Assumes `config.cache` is *fully* populated, see
+            `get_import_filepaths`.
+
+        """
+        for i_filepath in get_import_filepaths(self.filepath):
+            if i_filepath not in import_info_by_filepath:
+                import_info_by_filepath[i_filepath] = {
+                    "filepath": i_filepath,
+                    "filehash": get_file_hash(i_filepath),
+                }
+
+            self.imports.append(import_info_by_filepath[i_filepath])
+
+    def add_error(self, error: str) -> None:
+        """Add the given error to the file cache."""
+        self.errors.append(error)
+
+    def display_errors(self) -> None:
+        """Display the errors for the given cache."""
+        for error in self.errors:
+            print(error)
+
+    @property
+    def is_valid(self, filepath: Optional[str] = None) -> bool:
+        """Return `True` if the cache is valid for the given file.
+
+        If `filepath` is `None` it is assumed that the cache is being checked
+        for `self.filepath`. The common use case for this will be s.t.
+        >>> FileCache.from_file(cache_filepath).is_valid()
+        can be used in place of the more verbose
+        >>> FileCache.from_file(cache_filepath).is_valid(my_filepath)
+        where `my_filepath` is known to be the same as the filepath stored in the
+        cache.
+
+        """
+        # Default to the cache's filepath
+        if filepath is None:
+            filepath = self.filepath
+
+        if not isfile(filepath):
+            return False
+
+        # Validate version
+        if self.ratter_version != __version__:
+            return False
+
+        # Validate file
+        if self.filepath != filepath:
+            return False
+
+        if self.filehash != get_file_hash(filepath):
+            return False
+
+        # Validate imports
+        for i in self.imports:
+            i_filepath, i_filehash = i.get("filepath"), i.get("filehash")
+
+            if i_filepath is None or i_filehash is None:
+                return False
+
+            if i_filehash != get_file_hash(i_filepath):
+                return False
+
+        return True
+
+    @classmethod
+    def from_file(cls: Type[_FileCache], cache_filepath: str) -> _FileCache:
+        """Return the instance storing the cache from the given file.
+
+        NOTE On Security
+            Both jsonpickle and Python's provided pickle have notices on being
+            insecure [1,2]. Please see them for more information.
+
+        [1] - https://docs.python.org/3/library/pickle.html
+        [2] - http://jsonpickle.github.io/index.html#jsonpickle-usage
+
+        """
+        if not isfile(cache_filepath):
+            raise FileNotFoundError(cache_filepath)
+
+        with open(cache_filepath, "r") as f:
+            data = f.read()
+
+        return jsonpickle.decode(data)
+
+    def to_file(self, cache_filepath: Optional[str] = None) -> None:
+        """Write the current cache to the disk.
+
+        If `cache_filepath` is `None`, then the default file location for cache
+        files will be used.
+        See `util.get_cache_filepath(...)`.
+
+        If the cache is not fully populate for all files, then the saved
+        imports for this file may be incorrect, see `self.set_imports`.
+
+        """
+        if cache_filepath is None:
+            cache_filepath = get_cache_filepath(self.filepath)
+
+        # NOTE
+        #   Set cache imports, now is the best time as it is as populated as it
+        #   will be
+        self.set_imports()
+
+        with open(cache_filepath, "w") as f:
+            f.write(jsonpickle.encode(self))
+
+
+@dataclass
+class RatterCache:
+    changed: Set[str] = field(default_factory=set)
+    cache_by_file: Dict[str, FileCache] = field(default_factory=dict)
+
+    def has(self, filepath: str) -> bool:
+        """Return `True` if there is an up-to-date cache of the given file."""
+        return self.get(filepath) is not None
+
+    def get(self, filepath: str) -> Optional[FileCache]:
+        """Return the cache for the given file.
+
+        Priority:
+            1. the currently loaded caches (`self.cache_by_file`)
+            2. the cache file in the expected location, if valid
+            3. there is no cache
+
+        Side-effect:
+            On reaching priority 2, if the cache file exists and the contained
+            cache is valid then it will be read and loaded into
+            `self.cache_by_file`.
+
+        """
+        from ratter import config
+
+        if filepath in self.cache_by_file:
+            return self.cache_by_file[filepath]
+
+        if config.use_cache:
+            try:
+                cache = FileCache.from_file(get_cache_filepath(filepath))
+            except FileNotFoundError:
+                return None
+
+            if cache.is_valid:
+                self.cache_by_file[filepath] = cache
+                return cache
+
+        return None
+
+    def new(self, filepath: str) -> FileCache:
+        """Return and register a new cache for the given filepath."""
+        if self.has(filepath):
+            raise FileExistsError
+
+        self.cache_by_file[filepath] = FileCache()
+        self.cache_by_file[filepath].set_file_info(filepath)
+
+        self.changed.add(filepath)
+
+        return self.cache_by_file[filepath]
+
+    def get_or_new(self, filepath: str) -> FileCache:
+        """Return the cache for the given file, creating if needed."""
+        cached = self.get(filepath)
+
+        if cached is not None:
+            cached.display_errors()
+
+        return cached or self.new(filepath)
+
+    def write(self) -> None:
+        """Write all caches to their default locations.
+
+        NOTE
+            If an directly or indirectly imported file's cache is not
+            populated, then it will be excluded from the file cache's imports,
+            as such this should be called once, when analysis and cache
+            construction are complete.
+            See `cache.to_file`.
+
+        """
+        for filepath, cache in self.cache_by_file.items():
+            if filepath in self.changed:
+                cache.to_file()

--- a/ratter/cache/cache.py
+++ b/ratter/cache/cache.py
@@ -78,9 +78,7 @@ class FileCache:
     def set_imports(self) -> None:
         """Set the file imports for this cache.
 
-        NOTE
-            Assumes `config.cache` is *fully* populated, see
-            `get_import_filepaths`.
+        NOTE Assumes `config.cache` is complete, see `get_import_filepaths`.
 
         """
         for i_filepath in get_import_filepaths(self.filepath):
@@ -240,7 +238,7 @@ class RatterCache:
     def new(self, filepath: str) -> FileCache:
         """Return and register a new cache for the given filepath."""
         if self.has(filepath):
-            raise FileExistsError
+            raise ValueError(f"cache for '{filepath}' already loaded")
 
         self.cache_by_file[filepath] = FileCache()
         self.cache_by_file[filepath].set_file_info(filepath)

--- a/ratter/cache/util.py
+++ b/ratter/cache/util.py
@@ -102,12 +102,15 @@ def _get_direct_imports(filepath: str) -> List[Import]:
     from ratter import config
 
     if filepath in DO_NOT_CACHE:
-        return []
+        return list()
 
     cached = config.cache.get(filepath)
 
-    if cached is None or cached.ir is None:
+    if cached is None:
         return list()
+
+    if cached.ir is None:
+        raise ValueError(f"cache IR is not populated for '{filepath}'")
 
     ctx: Context = cached.ir.context
     imports: List[Import] = list()

--- a/ratter/cache/util.py
+++ b/ratter/cache/util.py
@@ -10,7 +10,6 @@ from ratter.analyser.context.context import Context
 from ratter.analyser.context.symbol import Import
 from ratter.analyser.util import is_pip_filepath, is_stdlib_filepath
 
-
 DO_NOT_CACHE = {"built-in", "frozen"}
 
 

--- a/ratter/cache/util.py
+++ b/ratter/cache/util.py
@@ -1,0 +1,124 @@
+"""Ratter cache util functions."""
+
+import hashlib
+import tempfile
+from os.path import isfile
+from pathlib import Path
+from typing import List, Optional, Set
+
+from ratter.analyser.context.context import Context
+from ratter.analyser.context.symbol import Import
+from ratter.analyser.util import is_pip_filepath, is_stdlib_filepath
+
+
+DO_NOT_CACHE = {"built-in", "frozen"}
+
+
+def get_file_hash(filepath: str, blocksize: int = 2 ** 20) -> Optional[str]:
+    """Return the hash of the given file, with a default blocksize of 1MiB."""
+    _hash = hashlib.md5()
+
+    if not isfile(filepath):
+        return None
+
+    with open(filepath, "rb") as f:
+        while True:
+            buffer = f.read(blocksize)
+
+            if not buffer:
+                break
+
+            _hash.update(buffer)
+
+    return _hash.hexdigest()
+
+
+def get_cache_filepath(filepath: str, mkdir: bool = True) -> str:
+    """Return the default cache filepath corresponding to the given file.
+
+    Side-effect:
+        The parent directory of the returned path will be created unless
+        `mkdir` is explicitly set to `False`.
+
+    """
+    dir_as_path = Path(filepath).parent
+    file_as_path = Path(filepath).with_suffix(".json").name
+
+    # NOTE
+    #   We don't really want to be clogging up /usr/lib/pypy and such with
+    #   cache files... So set to /tmp/.ratter/cache/usr/lib/pypy/* or OS
+    #   equivalent.
+    # NOTE Python Version Compatibility
+    #   `Path.parents` does not support splicing or negative indexing pre-3.10,
+    #   thus it is converted to a list.
+    #   https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parents
+    if filepath in DO_NOT_CACHE:
+        raise ValueError(f"can't cache built-in module at '{filepath}'")
+    elif is_pip_filepath(filepath) or is_stdlib_filepath(filepath):
+        tmp = Path(tempfile.gettempdir())
+        libpath = dir_as_path.relative_to(list(dir_as_path.parents)[-1])
+        new_dir_as_path = tmp / ".ratter" / "cache" / libpath
+    else:
+        new_dir_as_path = dir_as_path / ".ratter" / "cache"
+
+    # NOTE Create the containing path if it does not exist
+    if mkdir and not new_dir_as_path.is_dir():
+        new_dir_as_path.mkdir(parents=True)
+
+    return str(new_dir_as_path / file_as_path)
+
+
+def get_import_filepaths(filepath: str) -> Set[str]:
+    """Return all imports in the given file, recursively.
+
+    NOTE Assumes the cache is *fully* populated, see `_get_direct_imports`
+
+    """
+    imports: Set[str] = set()
+    queue: List[Import] = _get_direct_imports(filepath)
+
+    # BFS imports DAG (ignores cycles) to determine all direct and indirect
+    # imports from this file
+    for i in queue:
+        if i.module_spec is None or i.module_spec.origin is None:
+            continue
+
+        i_path = i.module_spec.origin
+
+        if i_path in DO_NOT_CACHE:
+            continue
+
+        if i_path in imports:
+            continue
+
+        imports.add(i_path)
+
+        queue += _get_direct_imports(i_path)
+
+    return imports
+
+
+def _get_direct_imports(filepath: str) -> List[Import]:
+    """Return the `Import` symbols in the IR of the given file.
+
+    NOTE Assumes the cache is *fully* populated.
+
+    """
+    from ratter import config
+
+    if filepath in DO_NOT_CACHE:
+        return []
+
+    cached = config.cache.get(filepath)
+
+    if cached is None or cached.ir is None:
+        return list()
+
+    ctx: Context = cached.ir.context
+    imports: List[Import] = list()
+
+    for symbol in ctx.symbol_table.symbols():
+        if isinstance(symbol, Import):
+            imports.append(symbol)
+
+    return imports

--- a/ratter/cache/util.py
+++ b/ratter/cache/util.py
@@ -86,6 +86,9 @@ def get_import_filepaths(filepath: str) -> Set[str]:
         if i_path in imports:
             continue
 
+        if i_path == filepath:
+            continue
+
         imports.add(i_path)
 
         queue += _get_direct_imports(i_path)

--- a/ratter/cli/parser.py
+++ b/ratter/cli/parser.py
@@ -69,7 +69,7 @@ def parse_arguments() -> Namespace:
         Output,
         FilterString,
         File,
-        Cache,
+        ResultsCache,
     )
 
     for argument_group_parser in ARGUMENT_GROUP_PARSERS:
@@ -414,11 +414,11 @@ class File(ArgumentGroupParser):
         return arguments
 
 
-class Cache(ArgumentGroupParser):
+class ResultsCache(ArgumentGroupParser):
     def register(parser: ArgumentParser) -> ArgumentParser:
-        cache_group = parser.add_argument_group()
-        cache_group.add_argument(
-            "--cache",
+        results_cache_group = parser.add_argument_group()
+        results_cache_group.add_argument(
+            "--cache-results",
             default="",
             type=str,
             help=multi_paragraph_wrap(
@@ -431,7 +431,7 @@ class Cache(ArgumentGroupParser):
         return parser
 
     def validate(parser: ArgumentParser, arguments: Namespace) -> Namespace:
-        f = arguments.cache
+        f = arguments.cache_results
         _, ext = splitext(f)
 
         if isfile(f):

--- a/ratter/cli/parser.py
+++ b/ratter/cli/parser.py
@@ -5,6 +5,7 @@ from os.path import isfile, splitext
 
 from ratter import error
 from ratter.cli.util import multi_paragraph_wrap
+from ratter.version import __version__
 
 
 def parse_arguments() -> Namespace:
@@ -54,7 +55,7 @@ def parse_arguments() -> Namespace:
         "-v",
         "--version",
         action="version",
-        version="%(prog)s 1.0.0",
+        version=f"%(prog)s {__version__}",
     )
 
     # TODO Allow user to add to this (will need config to respect this)

--- a/ratter/config/__init__.py
+++ b/ratter/config/__init__.py
@@ -53,8 +53,8 @@ class Config:
     # NOTE See `util.py::enter_file`
     current_file: Optional[str] = None
 
-    # Cache file
-    cache: str = ""
+    # File to cache results to
+    cache_results: str = ""
 
 
 config = Config()

--- a/ratter/config/__init__.py
+++ b/ratter/config/__init__.py
@@ -11,6 +11,8 @@ class Config:
 
     """
 
+    dry_run: bool = False
+
     # Import following
     follow_imports: int = 1
     follow_pip_imports: bool = False
@@ -55,6 +57,9 @@ class Config:
 
     # File to cache results to
     cache_results: str = ""
+
+    # Use IR cahce
+    ir_cache: bool = True
 
 
 config = Config()

--- a/ratter/config/__init__.py
+++ b/ratter/config/__init__.py
@@ -57,8 +57,8 @@ class Config:
     save_results: str = ""
 
     # Cache settings
-    use_cache: bool = True
-    save_cache: bool = True
+    use_cache: bool = False
+    save_cache: bool = False
 
     # HACK Below items constitute run-time state and are not strictly config
     # TODO

--- a/ratter/config/__init__.py
+++ b/ratter/config/__init__.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Optional, Set
 
+from ratter.cache import RatterCache
+
 
 @dataclass
 class Config:
@@ -51,15 +53,24 @@ class Config:
     # File info
     file: str = "<no_file>"
 
-    # HACK State, cleaner than passing [str | None] to dozens of functions
-    # NOTE See `util.py::enter_file`
+    # File to save cache results to
+    save_results: str = ""
+
+    # Cache settings
+    use_cache: bool = True
+    save_cache: bool = True
+
+    # HACK Below items constitute run-time state and are not strictly config
+    # TODO
+    #   Move state somewhere intelligent, without having to pass state
+    #   to/through dozens of functions making the function signatures messier
+    #   than needed
+
+    # See `util.py::enter_file`
     current_file: Optional[str] = None
 
-    # File to cache results to
-    cache_results: str = ""
-
-    # Use IR cahce
-    ir_cache: bool = True
+    # See `RatterCache`
+    cache: RatterCache = field(default_factory=RatterCache)
 
 
 config = Config()

--- a/ratter/plugins/analysers/builtins.py
+++ b/ratter/plugins/analysers/builtins.py
@@ -3,7 +3,7 @@
 import ast
 
 from ratter.analyser.base import CustomFunctionAnalyser
-from ratter.analyser.context import Context
+from ratter.analyser.context.context import Context
 from ratter.analyser.types import FuncOrAsyncFunc, FunctionIR
 from ratter.analyser.util import get_dynamic_name, get_fullname
 

--- a/ratter/plugins/analysers/collections.py
+++ b/ratter/plugins/analysers/collections.py
@@ -3,7 +3,7 @@
 import ast
 
 from ratter.analyser.base import CustomFunctionAnalyser
-from ratter.analyser.context import Context
+from ratter.analyser.context.context import Context
 from ratter.analyser.types import FuncOrAsyncFunc, FunctionIR
 
 

--- a/ratter/version.py
+++ b/ratter/version.py
@@ -1,7 +1,7 @@
 """Store the semantic version of Ratter."""
 
-major = 1
-minor = 1
-patchlevel = 0
+major = 0
+minor = 2
+patchlevel = 1
 
 __version__ = f"{major}.{minor}.{patchlevel}"

--- a/ratter/version.py
+++ b/ratter/version.py
@@ -1,0 +1,7 @@
+"""Store the semantic version of Ratter."""
+
+major = 1
+minor = 1
+patchlevel = 0
+
+__version__ = f"{major}.{minor}.{patchlevel}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonpickle

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 
 from setuptools import setup, find_packages
+from distutils.util import convert_path
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -9,14 +10,21 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "README.md"), "r") as f:
     DESCRIPTION = f.read()
 
+
 # Copy requirements from requirements.txt
 with open(os.path.join(here, "requirements.txt"), "r") as f:
     INSTALL_REQUIRES = [line.strip() for line in f.readlines()]
 
 
+# Get version
+version = {}
+with open(convert_path("ratter/version.py")) as f:
+    exec(f.read(), version)
+
+
 setup(
     name="ratter",
-    version="1.0.0",
+    version=version.get("__version__"),
     author="Suade Labs",
     packages=find_packages(),
     description="Python 3.7 function analyser",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import ratter
 
 from ratter.analyser.base import CustomFunctionAnalyser, CustomFunctionHandler
-from ratter.analyser.context import Context, RootContext
+from ratter.analyser.context.context import Context, RootContext
 from ratter.analyser.context.symbol import Call, Name
 from ratter.analyser.types import FileIR, FuncOrAsyncFunc, FunctionIR
 from ratter.analyser.util import LOCAL_VALUE_PREFIX

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -2,10 +2,9 @@ import ast
 import mock
 
 
-from ratter.analyser.context import (
-    Context,
-    RootContext,
-    SymbolTable,
+from ratter.analyser.context.context import Context, RootContext
+from ratter.analyser.context.symbol_table import SymbolTable
+from ratter.analyser.context.symbol import (
     Name,
     Builtin,
     Import,

--- a/tests/context/test_symbol_table.py
+++ b/tests/context/test_symbol_table.py
@@ -1,4 +1,5 @@
-from ratter.analyser.context import SymbolTable, Name
+from ratter.analyser.context.symbol_table import SymbolTable
+from ratter.analyser.context.symbol import Name
 
 
 class TestSymbolTable:

--- a/tests/plugins/analysers/test_builtins.py
+++ b/tests/plugins/analysers/test_builtins.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ratter.analyser.context import (
-    RootContext,
+from ratter.analyser.context.context import RootContext
+from ratter.analyser.context.symbol import (
     Call,
     Func,
     Name,

--- a/tests/plugins/analysers/test_collections.py
+++ b/tests/plugins/analysers/test_collections.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ratter.analyser.context import (
-    RootContext,
+from ratter.analyser.context.context import RootContext
+from ratter.analyser.context.symbol import (
     Builtin,
     Call,
     Func,

--- a/tests/plugins/assertors/test_import_clobbering.py
+++ b/tests/plugins/assertors/test_import_clobbering.py
@@ -1,6 +1,6 @@
 import mock
 
-from ratter.analyser.context import RootContext
+from ratter.analyser.context.context import RootContext
 from ratter.plugins.assertors.import_clobbering import ImportClobberingAssertor
 
 

--- a/tests/test_analysers.py
+++ b/tests/test_analysers.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from ratter.analyser.context import RootContext
+from ratter.analyser.context.context import RootContext
 from ratter.analyser.file import FileAnalyser
 
 from ratter.analyser.context.symbol import (

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,7 @@
 from functools import partial
 import hashlib
 import mock
+import os
 import pytest
 import tempfile
 from itertools import combinations
@@ -38,6 +39,13 @@ def mocked_module_spec(origin: str):
     m_module_spec.origin = origin
 
     return m_module_spec
+
+
+def get_relative_libpath(lib: str) -> Path:
+    if "\\" in lib and os.name == "nt":
+        return Path(Import(lib).module_spec.origin[3:]).parent
+
+    return Path(Import(lib).module_spec.origin[1:]).parent
 
 
 class TestFileCache:
@@ -386,7 +394,7 @@ class TestCacheUtils:
 
         # Is pip module
         filepath = get_cache_filepath_safe(Import("flask").module_spec.origin)
-        rel_libpath = Path(Import("flask").module_spec.origin[1:]).parent
+        rel_libpath = get_relative_libpath("flask")
         assert filepath.startswith(tmp)
         assert filepath == str(
             Path(tmp) / ".ratter" / "cache" / rel_libpath / "__init__.json"
@@ -394,7 +402,7 @@ class TestCacheUtils:
 
         # Is stdlib module
         filepath = get_cache_filepath_safe(Import("pathlib").module_spec.origin)
-        rel_libpath = Path(Import("pathlib").module_spec.origin[1:]).parent
+        rel_libpath = get_relative_libpath("pathlib")
         assert filepath.startswith(tmp)
         assert filepath == str(
             Path(tmp) / ".ratter" / "cache" / rel_libpath / "pathlib.json"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -41,11 +41,11 @@ def mocked_module_spec(origin: str):
     return m_module_spec
 
 
-def get_relative_libpath(lib: str) -> Path:
-    if "\\" in lib and os.name == "nt":
-        return Path(Import(lib).module_spec.origin[3:]).parent
+def get_relative_libpath(lib: str) -> str:
+    libdir = Path(Import(lib).module_spec.origin).parent
+    drive_or_root = list(libdir.parents)[-1]
 
-    return Path(Import(lib).module_spec.origin[1:]).parent
+    return str(libdir.relative_to(drive_or_root))
 
 
 class TestFileCache:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,120 @@
+import hashlib
+import os
+import tempfile
+from itertools import combinations
+from pathlib import Path
+
+from ratter.analyser.context.symbol import Import
+from ratter.cache.util import get_cache_filepath, get_file_hash
+
+
+def get_cache_filepath_safe(filepath: str) -> str:
+    return get_cache_filepath(filepath, mkdir=False)
+
+
+class TestFileCache:
+
+    def test_set_file_info(self):
+        raise AssertionError
+
+    def test_set_imports(self):
+        raise AssertionError
+
+    def test_add_error(self):
+        raise AssertionError
+
+    def test_display_errors(self):
+        raise AssertionError
+
+    def test_is_valid(self):
+        raise AssertionError
+
+
+
+class TestRatterCache:
+
+    def test_has(self):
+        raise AssertionError
+
+    def test_get(self):
+        raise AssertionError
+
+    def test_new(self):
+        raise AssertionError
+
+    def test_get_or_new(self):
+        raise AssertionError
+
+
+class TestCacheUtils:
+
+    def test_get_file_hash_no_file(self):
+        assert get_file_hash("i-do-not-exist") is None
+    
+    def test_get_file_hash_sanity(self):
+        # Get MD5 of raw file
+        with open(__file__, "rb") as f:
+            _hash = hashlib.md5()
+            _hash.update(f.read())
+
+        hashes = [
+            _hash.hexdigest(),              # full file in one buffer
+            get_file_hash(__file__, 2**9),  # 500KiB blocks
+            get_file_hash(__file__, 2**10), # 1MiB blocks
+            get_file_hash(__file__, 2**11), # 2MiB blocks
+        ]
+
+        # Make sure that __file__ is hashed correctly
+        assert all(h is not None for h in hashes)
+
+        # Assert that all hashes are equal
+        for lhs, rhs in combinations(hashes, 2):
+            assert lhs == rhs
+
+    def test_get_cache_filepath(self):
+        tmp = tempfile.gettempdir()
+
+        # Is pip module
+        filepath = get_cache_filepath_safe(Import("flask").module_spec.origin)
+        rel_libpath = Path(Import("flask").module_spec.origin[1:]).parent
+        assert filepath.startswith(tmp)
+        assert filepath == str(
+            Path(tmp) / ".ratter" / "cache" / rel_libpath / "__init__.json"
+        )
+
+        # Is stdlib module
+        filepath = get_cache_filepath_safe(Import("pathlib").module_spec.origin)
+        rel_libpath = Path(Import("pathlib").module_spec.origin[1:]).parent
+        assert filepath.startswith(tmp)
+        assert filepath == str(
+            Path(tmp) / ".ratter" / "cache" / rel_libpath / "pathlib.json"
+        )
+
+        SOURCE = Path(__file__).parent.parent / "ratter" /  "cache"
+        BASE = SOURCE / ".ratter" / "cache"
+
+        # Is local module
+        filepath = get_cache_filepath_safe(
+            Import("ratter.cache.cache").module_spec.origin
+        )
+        assert not filepath.startswith(tmp)
+        assert filepath == str(BASE / "cache.json")
+
+        # Is local module, __init__.py
+        filepath = get_cache_filepath_safe(
+            Import("ratter.cache").module_spec.origin
+        )
+        assert not filepath.startswith(tmp)
+        assert filepath == str(BASE / "__init__.json")
+
+        # mkdir=True
+        cachepath = BASE / "cache.json"
+        assert not cachepath.parent.is_dir()
+        filepath = get_cache_filepath(
+            Import("ratter.cache.cache").module_spec.origin
+        )
+        assert cachepath.parent.is_dir()
+
+        # Clean-up
+        cachepath.parent.rmdir()
+        assert not cachepath.parent.is_dir()

--- a/tests/test_cls.py
+++ b/tests/test_cls.py
@@ -1,10 +1,10 @@
-from ratter.analyser.context import (
+from ratter.analyser.context.context import (
     RootContext,
-    Call,
     Class,
     Func,
     Name,
 )
+from ratter.analyser.context.symbol import Call
 from ratter.analyser.file import FileAnalyser
 
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,7 +1,7 @@
 from ratter.analyser.file import FileAnalyser
 
-from ratter.analyser.context import (
-    RootContext,
+from ratter.analyser.context.context import RootContext
+from ratter.analyser.context.symbol import (
     Builtin,
     Call,
     Class,

--- a/tests/test_ir_dag.py
+++ b/tests/test_ir_dag.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from ratter.analyser.context import Builtin, Call, Func, Name, Import
+from ratter.analyser.context.symbol import Builtin, Call, Func, Name, Import
 from ratter.analyser.context.symbol import Class
 from ratter.analyser.ir_dag import (
     IrDagNode,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,5 @@
-from ratter.analyser.context import (
-    RootContext,
+from ratter.analyser.context.context import RootContext
+from ratter.analyser.context.symbol import (
     Builtin,
     Call,
     Func,

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,7 +1,6 @@
 import mock
 
-from ratter.analyser.context import Call, Func, Name, Import
-from ratter.analyser.context.symbol import Class
+from ratter.analyser.context.symbol import Call, Class, Func, Name, Import
 from ratter.analyser.results import generate_results_from_ir
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,12 +4,11 @@ import mock
 import pytest
 
 from ratter import error
-from ratter.analyser.context import (
+from ratter.analyser.context.context import Context, RootContext
+from ratter.analyser.context.symbol import (
     Call,
     Class,
-    Context,
     Name,
-    RootContext,
 )
 from ratter.analyser.util import (
     assignment_is_one_to_one,


### PR DESCRIPTION
Closes #13 

## What / How

* Add semantic version info to Ratter
* Rename existing cache to "results cache" to avoid ambiguity with new IR cache
* Invalidate results cache if the current Ratter version differs from the producing Ratter version
* Add `--dry-run` CLI option to test future CLI options
* Rename `--cache` to `--save-results`
* Add `--no-cache` to disable the use of the IR cache
* Add `FileCache` and `RatterCache` classes to cache the results during run-time
* Add `--force-refresh-cache` to not use cache, but write it on success
* Add cache serialisation/de-serialisation via [jsonpickle](http://jsonpickle.github.io/) s.t. the cache remains human readable
* Add security notice regarding cache and `importlib.util.find_spec`


## TODO

* Fix starred imports breaking (run on `metrics.py` for example)
* Why does `Parse / analyse imports` in `-s` take c. double the time when reading cache?
* Security note: `--save-results` also has to be off to avoid use of `jsonpickle`
