### PR TITLE
Fix permissive cli arg overwrite bug

### DIFF
--- a/rattr/cli/parser.py
+++ b/rattr/cli/parser.py
@@ -460,11 +460,9 @@ class StrictOrPermissive(ArgumentGroupParser):
     def validate(parser: ArgumentParser, arguments: Namespace) -> Namespace:
 
         if not arguments.strict:
-            # only set threshold and reset permissive when threshold
-            # attribute doesn't exist. this is because threshold will
-            # already be set when we parse cli args into namespace
-            # and that will make 'arguments.threshold' = True or 0 (= True)
-            if not hasattr(arguments, "threshold"):
+            # only set threshold and permissive
+            # when permissive is freshly set to an int
+            if isinstance(arguments.permissive, int):
                 arguments.threshold = arguments.permissive or 0
                 arguments.permissive = True
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -839,3 +839,8 @@ def sys_args3():
 @pytest.fixture
 def sys_args4():
     return ["rattr", "rattr/cli/parser.py", "-S"]
+
+
+@pytest.fixture
+def sys_args5():
+    return ["rattr", "rattr/cli/parser.py", "--permissive", "3"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -237,3 +237,30 @@ class TestParser:
         )
 
         assert args == exp_args
+
+    def test_permissive_cli_call_overwrite(self, sys_args5, correct_toml_dict2):
+        args = parse_arguments(
+            sys_args=sys_args5[1:],
+            project_toml_cfg=correct_toml_dict2,
+            exit_on_error=False,
+        )
+
+        exp_args = Namespace(
+            follow_imports=3,
+            exclude_import=["a\\.a\\.a", "b\\.b.*", "c\\.c\\.c\\.c", "d\\d\\.d.*"],
+            exclude=["a_.*", "b_.*", "c_.*"],
+            show_warnings="all",
+            show_path="full",
+            strict=False,
+            permissive=True,
+            show_ir=False,
+            show_results=True,
+            show_stats=False,
+            silent=False,
+            cache="cache.json",
+            threshold=3,
+            filter_string="",
+            file="rattr/cli/parser.py",
+        )
+
+        assert args == exp_args


### PR DESCRIPTION
fixing a bug with cli overwriting permissive arg when it was already set in .toml